### PR TITLE
Add simple method of configuring via envars

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,17 +4,29 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/caarlos0/env"
 )
 
 func ReadConfig(configName string, target interface{}) error {
 	filename := fmt.Sprintf("/etc/sensu/%s.json", configName)
+
+	// First attempt to open the file
 	file, err := os.Open(filename)
-	if err != nil {
+	if err == nil {
+		decoder := json.NewDecoder(file)
+		err = decoder.Decode(target)
+		if err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		// We don't need the error if it was a does not exist because it's still
+		// possible to configure via envars.
 		return err
 	}
 
-	decoder := json.NewDecoder(file)
-	err = decoder.Decode(target)
+	// Override any json value with envars
+	err = env.Parse(target)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/sensu-utils/toolbox
 
 require (
+	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/coreos/etcd v3.3.12+incompatible // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/echlebek/timeproxy v1.0.0 // indirect


### PR DESCRIPTION
It seems common to allow the usage of envars to configure handlers as well as config files, so this is being updated to look for envars as well if configured in the config struct.